### PR TITLE
feat: use commitlint to validate commit messages

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,19 @@
+# Commitlint configuration.
+---
+extends: '@commitlint/config-conventional'
+
+rules:
+  # See: https://commitlint.js.org/reference/rules.html
+  #
+  # Rules are made up by a name and a configuration array. The configuration array contains:
+  #
+  # * Severity [0..2]: 0 disable rule, 1 warning if violated, or 2 error if violated
+  # * Applicability [always|never]: never inverts the rule
+  # * Value: value to use for this rule
+  #
+  # Run `npx commitlint --print-config` to see the current setting for all rules.
+  #
+  body-leading-blank:    [2, 'always']
+  footer-leading-blank:  [2, 'always']
+  type-enum:             [2, 'always', ['chore', 'feat', 'fix', 'revert']]
+

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -1,24 +1,26 @@
 name: Conventional Commits
 
-on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
+# Modeled after https://github.com/oss-review-toolkit/ort
 
-permissions:
-  pull-requests: read
+on:
+  pull_request:
+    branches:
+      - main
+
+  push:
+    branches:
+      - main
 
 jobs:
-  main:
-    name: Validate Commits
+  commit-lint:
+    name: Validate commits
+
     runs-on: ubuntu-latest
+
     steps:
-      - uses: taskmedia/action-conventional-commits@v1.1.18
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          types: "feat|fix|chore|revert"
-          skip_merge: true
-          skip_revert: true
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Check Commit Messages
+        uses: wagoid/commitlint-github-action@v6
+        with: { configFile: .commitlintrc.yml }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@commitlint/cli": "^19.5.0",
+    "@commitlint/config-conventional": "^19.5.0"
+  }
+}


### PR DESCRIPTION
Use [commitlint](https://commitlint.js.org) instead of taskmedia/action-conventional-commits