### PR TITLE
Validate commit message with a git hook

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,4 +1,3 @@
-# Commitlint configuration.
 ---
 extends: '@commitlint/config-conventional'
 
@@ -15,5 +14,3 @@ rules:
   #
   body-leading-blank:    [2, 'always']
   footer-leading-blank:  [2, 'always']
-  type-enum:             [2, 'always', ['chore', 'feat', 'fix', 'revert']]
-

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no-install commitlint --edit "$1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
-    "@commitlint/config-conventional": "^19.5.0"
+    "@commitlint/config-conventional": "^19.5.0",
+    "husky": "^9.1.0"
+  },
+  "scripts": {
+    "prepare": "husky"
   }
 }


### PR DESCRIPTION
Validate that each commit message is formatted correctly as a conventional commit.

This change installs and uses [Husky](https://typicode.github.io/husky/) which is a utility which manages commit hooks.

It also adds a commit-msg hook to validate each commit message with commitlint.